### PR TITLE
Adds Drupal Group relationship changes as a preservation trigger

### DIFF
--- a/rootfs/var/www/leaf-isle-bagger/drupal/api.py
+++ b/rootfs/var/www/leaf-isle-bagger/drupal/api.py
@@ -63,6 +63,38 @@ def get_media_list(session, server, page=0, date_filter=""):
 
 
 #
+def group_view_endpoint(page=0, date_filter=""):
+    return (
+        f"views/preservation/v2/show_drupal_group/timestamps?"
+        f"page={page}&group_changed={date_filter}&group_relationship_changed={date_filter}"
+    )
+
+
+#
+def get_drupal_groups_list(session, server, page=0, date_filter=""):
+
+    response = session.get(
+        urljoin(server, group_view_endpoint(page, date_filter)),
+    )
+    response.raise_for_status()
+    return response
+
+
+#
+def group_node_view_endpoint(node_id):
+    return f"views/preservation/v2/show_drupal_groups/node/{node_id}"
+
+
+#
+def get_groups_by_node(session, server, node_id):
+    response = session.get(
+        urljoin(server, group_node_view_endpoint(node_id)),
+    )
+    response.raise_for_status()
+    return response
+
+
+#
 def get_node_by_format(session, server, item_id):
     response = session.get(
         urljoin(server, f"node/{item_id}?_format=json"),

--- a/rootfs/var/www/leaf-isle-bagger/drupal/utilities.py
+++ b/rootfs/var/www/leaf-isle-bagger/drupal/utilities.py
@@ -100,6 +100,32 @@ def single_node_merge_with_media(session, server, node_list, node_id):
                 logging.info(f"  Updating node list changed date : {node_list}")
 
 
+# Query Group because media updates are not reflected in associated Node change timestamps
+# exclude Drupal Media not attached to a Drupal Node
+# Apply only to the single node case
+def single_node_merge_with_drupal_group(session, server, node_list, node_id):
+    try:
+        node_id = node_id if isinstance(node_id, int) else int(node_id)
+    except ValueError:
+        logging.error(f"Invalid node id {node_id}")
+    else:
+        # Get assocaiated Media
+        associated_json = drupalApi.get_groups_by_node(session, server, node_id)
+        associated_group = json.loads(associated_json.content)
+        for group in associated_group:
+            group_changed = get_changed_date(group)
+            node = node_list.get(node_id, None)
+
+            if (
+                group_changed is not None
+                and node is not None
+                and node["changed"] < group_changed
+            ):
+                # group changed but the parent node did not change
+                node_list[node_id]["changed"] = group_changed
+                logging.info(f"  Updating node list changed date : {node_list}")
+
+
 # query media as media changes are not reflected as node revisions
 # exclude Drupal Media not attached to a Drupal Node
 def id_list_merge_with_media(session, args, node_list):
@@ -141,6 +167,68 @@ def id_list_merge_with_media(session, args, node_list):
                 ):
                     # media changed but the parent node did not change
                     add_to_node_list(node_list, media_of, media_changed)
+            page += 1
+
+
+#
+def get_changed_date(group_relationship):
+
+    group_changed_on = group_relationship.get("group_changed_on", None)
+    group_relationship_changed_on = group_relationship.get(
+        "group_relationship_changed_on", None
+    )
+
+    if not group_changed_on and group_relationship_changed_on:
+        return drupal_to_iso8601(group_relationship_changed_on)
+    elif group_changed_on and not group_relationship_changed_on:
+        return drupal_to_iso8601(group_changed_on)
+    elif group_changed_on >= group_relationship_changed_on:
+        return drupal_to_iso8601(group_changed_on)
+    elif group_changed_on <= group_relationship_changed_on:
+        return drupal_to_iso8601(group_relationship_changed_on)
+    else:
+        return None
+
+
+# query Drupal Groups as group changes are not reflected as node revisions
+# exclude Drupal Groups not attached to a Drupal Node
+def id_list_merge_with_drupal_groups(session, args, node_list):
+
+    page = 0
+    while True:
+        groups = drupalApi.get_drupal_groups_list(session, args.server, page, args.date)
+        groups_json = json.loads(groups.content)
+        logging.debug(
+            "Page %s of group content - count[%s] - %s",
+            page,
+            len(groups_json),
+            groups_json,
+        )
+
+        if len(groups_json) == 0:
+            # no more pages
+            break
+        else:
+            for group_relationship in groups_json:
+                node_id = None
+                if (
+                    "field_group_of" in group_relationship
+                    and len(group_relationship["field_group_of"]) >= 1
+                ):
+                    node_id = group_relationship["field_group_of"]
+
+                group_changed = get_changed_date(group_relationship)
+
+                if (
+                    node_id is not None
+                    and group_changed is not None
+                    and (
+                        node_id not in node_list
+                        or node_list[node_id]["changed"] < group_changed
+                    )
+                ):
+                    # group changed but the parent node did not change
+                    add_to_node_list(node_list, node_id, group_changed)
             page += 1
 
 

--- a/rootfs/var/www/leaf-isle-bagger/drupal/utilities.py
+++ b/rootfs/var/www/leaf-isle-bagger/drupal/utilities.py
@@ -212,10 +212,10 @@ def id_list_merge_with_drupal_groups(session, args, node_list):
             for group_relationship in groups_json:
                 node_id = None
                 if (
-                    "field_group_of" in group_relationship
-                    and len(group_relationship["field_group_of"]) >= 1
+                    "node_id" in group_relationship
+                    and len(group_relationship["node_id"]) >= 1
                 ):
-                    node_id = group_relationship["field_group_of"]
+                    node_id = group_relationship["node_id"]
 
                 group_changed = get_changed_date(group_relationship)
 

--- a/rootfs/var/www/leaf-isle-bagger/leaf-bagger-audit.py
+++ b/rootfs/var/www/leaf-isle-bagger/leaf-bagger-audit.py
@@ -68,12 +68,18 @@ def process(args, session, output_file):
         f"Audit: Drupal nodes before media inclusion - length [{len(node_list)}] - details {node_list}"
     )
 
-    # inspect Drupal Media for changes
+    # Inspect Drupal Media for changes
     # a Media change is does not transitively change the associated Node change timestamp)
     # if Media changed then add associated Node ID to the list
     drupalUtilities.id_list_merge_with_media(session, args, node_list)
     logging.info(
         f"Audit: Drupal nodes with media changes - length [{len(node_list)}] - details {node_list}"
+    )
+
+    # Inspect Drupal Group relationship for changes
+    drupalUtilities.id_list_merge_with_drupal_groups(session, args, node_list)
+    logging.info(
+        f"Audit: Drupal nodes with group relationship changes - length [{len(node_list)}] - details {node_list}"
     )
 
     # audit archival information packages

--- a/rootfs/var/www/leaf-isle-bagger/leaf-bagger.py
+++ b/rootfs/var/www/leaf-isle-bagger/leaf-bagger.py
@@ -91,16 +91,26 @@ def process(args, session):
             session, args.server, node_list, args.force_single_node
         )
         logging.info(f"AIP: Drupal node with media changes - {node_list}")
+        # Inspect Drupal Group relationship for changes
+        drupalUtilities.single_node_merge_with_drupal_groups(
+            session, args.server, node_list, args.force_single_node
+        )
+        logging.info(f"AIP: Drupal node with group relationship changes - {node_list}")
     else:
         # get a list of Drupal Node IDs changed since a given optional date
         # or a single node then force update
         node_list = drupalUtilities.id_list_from_nodes(session, args)
         logging.info(f"AIP: Drupal nodes before media inclusion - {node_list}")
+
         # inspect associated Drupal Media for changes
         # a Media change does not transitively update the associated Node change timestamp)
         # if Media changed but not the associated Node then add associated Node ID to the list
         drupalUtilities.id_list_merge_with_media(session, args, node_list)
         logging.info(f"AIP: Drupal nodes with media changes - {node_list}")
+
+        # inspect Drupal Group relationship for changes
+        drupalUtilities.id_list_merge_with_drupal_groups(session, args, node_list)
+        logging.info(f"AIP: Drupal nodes with group relationship changes - {node_list}")
 
     # create archival information packages
     logging.info("Create AIPs")

--- a/rootfs/var/www/leaf-isle-bagger/tests/test_drupal.py
+++ b/rootfs/var/www/leaf-isle-bagger/tests/test_drupal.py
@@ -51,9 +51,16 @@ def test_drupal_node_change_view(mocker):
         f"{args.server}/{drupalApi.node_view_endpoint(page='0', date_filter=args.date)}",
         text='[ { "nid" : "1", "changed" : "1704067200" } ]',
     )
+    # Test both English and French translations that yeilds 2 nodes in the view with the same ID
+    # use the lates one
     _adapter.register_uri(
         "GET",
         f"{args.server}/{drupalApi.node_view_endpoint(page='1', date_filter=args.date)}",
+        text='[ { "nid" : "1", "changed" : "1604067200" } ]',
+    )
+    _adapter.register_uri(
+        "GET",
+        f"{args.server}/{drupalApi.node_view_endpoint(page='2', date_filter=args.date)}",
         text="[]",
     )
     node_list = drupalUtilities.id_list_from_nodes(_session, args)
@@ -181,3 +188,98 @@ def test_single_drupal_node_change_without_media(mocker):
     )
     assert node_list[node_id]
     assert node_list[node_id]["changed"] == "2022-05-18T13:35:52+00:00"
+
+
+# Test Drupal Group update inclusion
+def test_drupal_group_change_date():
+    date_gr = drupalUtilities.get_changed_date(
+        {
+            "group_changed_on": "1758126493",
+            "group_relationship_changed_on": "1774280464",
+        }
+    )
+    date_g = drupalUtilities.get_changed_date(
+        {
+            "group_changed_on": "1774280464",
+            "group_relationship_changed_on": "1758126493",
+        }
+    )
+    date_gr_none = drupalUtilities.get_changed_date(
+        {
+            "group_changed_on": "1774280464",
+            "group_relationship_changed_on": "",
+        }
+    )
+    date_g_none = drupalUtilities.get_changed_date(
+        {
+            "group_changed_on": "",
+            "group_relationship_changed_on": "1758126493",
+        }
+    )
+    assert date_gr == "2026-03-23T15:41:04+00:00"
+    assert date_g == "2026-03-23T15:41:04+00:00"
+    assert date_gr_none == "2026-03-23T15:41:04+00:00"
+    assert date_g_none == "2025-09-17T16:28:13+00:00"
+
+
+# Test Drupal Group change view
+def test_drupal_group_change(mocker):
+    mocker.patch(
+        "argparse.ArgumentParser.parse_args",
+        return_value=argparse.Namespace(date="2023-01-01", server="http://example.com"),
+    )
+    args = argparse.ArgumentParser.parse_args()
+    _adapter.register_uri(
+        "GET",
+        f"{args.server}/{drupalApi.group_view_endpoint(page='0', date_filter=args.date)}",
+        text='[ { "group_changed_on": "1758126493", "group_relationship_changed_on": "1774280464",'
+        ' "field_group_of": "1" } ]',
+    )
+    _adapter.register_uri(
+        "GET",
+        f"{args.server}/{drupalApi.group_view_endpoint(page='1', date_filter=args.date)}",
+        text="[]",
+    )
+    node_list = {"1": {"changed": "2024-01-01T00:00:00+00:00"}}
+    drupalUtilities.id_list_merge_with_drupal_groups(_session, args, node_list)
+    assert node_list["1"]
+    assert node_list["1"]["changed"] == "2026-03-23T15:41:04+00:00"
+
+
+# Test the update of a single node with associated media
+# test that the date list captures the media date not the node date
+def test_single_drupal_node_change_with_recent_group_change_date(mocker):
+    node_id = 9999
+    node_list = {
+        9999: {
+            "changed": "2022-05-18T13:35:49+00:00",
+            "content_type": "application/zip",
+        }
+    }
+    mocker.patch(
+        "argparse.ArgumentParser.parse_args",
+        return_value=argparse.Namespace(
+            force_single_node=node_id, date="2023-01-01", server="http://example.com"
+        ),
+    )
+    args = argparse.ArgumentParser.parse_args()
+    _adapter.register_uri(
+        "GET",
+        f"{args.server}/{drupalApi.media_associated_with_node_endpoint(node_id)}",
+        text='[ { "changed": [{"value": "2022-05-18T13:35:52+00:00"}], "field_media_of": [{"target_id": 9999}] } ]',
+    )
+    drupalUtilities.single_node_merge_with_media(
+        _session, args.server, node_list, args.force_single_node
+    )
+
+    _adapter.register_uri(
+        "GET",
+        f"{args.server}/{drupalApi.group_node_view_endpoint(node_id)}",
+        text='[ { "group_changed_on": "1758126493", "group_relationship_changed_on": "1774280464",'
+        ' "field_group_of": "1" } ]',
+    )
+    drupalUtilities.single_node_merge_with_drupal_group(
+        _session, args.server, node_list, args.force_single_node
+    )
+    assert node_list[node_id]
+    assert node_list[node_id]["changed"] == "2026-03-23T15:41:04+00:00"

--- a/rootfs/var/www/leaf-isle-bagger/tests/test_drupal.py
+++ b/rootfs/var/www/leaf-isle-bagger/tests/test_drupal.py
@@ -233,7 +233,7 @@ def test_drupal_group_change(mocker):
         "GET",
         f"{args.server}/{drupalApi.group_view_endpoint(page='0', date_filter=args.date)}",
         text='[ { "group_changed_on": "1758126493", "group_relationship_changed_on": "1774280464",'
-        ' "field_group_of": "1" } ]',
+        ' "node_id": "1" } ]',
     )
     _adapter.register_uri(
         "GET",


### PR DESCRIPTION
Address #63 

Changes to the Drupal Group relationship do not trigger a preservation event. Now that preservation captures Drupal Group information, a change to the Drupal Group should trigger a preservation of the impacted items.

* Adds Drupal Group relationship changes as a preservation trigger
* Adds to audit